### PR TITLE
bug fix for list_msfiles()

### DIFF
--- a/solar_realtime_pipeline.py
+++ b/solar_realtime_pipeline.py
@@ -190,7 +190,6 @@ def list_msfiles(intime, lustre=True, file_path='slow', server=None, time_interv
                         msfiles.append({'path': filestr, 'name': filename, 'time': timestr, 'freq': freqstr})
             else:
                 logging.info('Did not find any files at the given time {0:s}.'.format(intime.isot)) 
-                msfiles=[]
     else:
         if server:
             cmd = 'ssh ' + server + ' ls ' + file_path + ' | grep ' + tstr


### PR DESCRIPTION
Found a bug in the list_msfiles() module. It resets the entire returned list of ms files if it cannot access one of the bands. It explains why all the low bands are blank on 2024 July 19 when slow viz has 36, 50, 73 MHz missing and fast viz has 50 MHz missing. Therefore the routine only returns 78 and 82 MHz for slow and >50 MHz for fast. Simply removing one line may fix the issue.